### PR TITLE
feature/header UI optimizations

### DIFF
--- a/assets/scss/00-settings/_variables-bootstrap.scss
+++ b/assets/scss/00-settings/_variables-bootstrap.scss
@@ -15,3 +15,7 @@ $headings-font-family:      $font-family-serif;
 $border-radius:             .4rem;
 $border-radius-lg:          .5rem;
 $border-radius-sm:          .3rem;
+
+// Navbar
+
+$navbar-dark-toggler-border-color:      transparent;

--- a/assets/scss/05-components/the-header-menu.scss
+++ b/assets/scss/05-components/the-header-menu.scss
@@ -25,21 +25,20 @@
     height: 100vh;
 }
 
-.navbar-brand {
+.navbar-bar {
+    display: flex;
+    flex-grow: 1;
+    justify-content: space-between;
     order: 1;
 }
 
-.navbar-toggler {
-    order: 2;
-}
-
 .navbar-body-search {
-    order: 3;
+    order: 2;
 }
 
 .navbar-body-main {
     display: none;
-    order: 4;
+    order: 3;
     padding-right: $navbar-padding-x;
     padding-left: $navbar-padding-x;
     background-color: $dark;
@@ -58,6 +57,10 @@
 
     .navbar-body-main-open {
         height: auto;
+    }
+
+    .navbar-bar {
+        flex-grow: 0;
     }
 
     .navbar-body-main {

--- a/assets/scss/05-components/the-header-menu.scss
+++ b/assets/scss/05-components/the-header-menu.scss
@@ -24,9 +24,14 @@
     top: 100%;
     right: 0;
     left: 0;
+    display: none;
     padding-right: $navbar-padding-x;
     padding-left: $navbar-padding-x;
     background-color: $dark;
+
+    &.show {
+        display: block;
+    }
 }
 
 .navbar-body-search {
@@ -46,6 +51,7 @@
 
         .navbar-body-main {
             position: static;
+            display: block;
             flex-grow: 0;
             order: 3;
             padding-right: 0;

--- a/assets/scss/05-components/the-header-menu.scss
+++ b/assets/scss/05-components/the-header-menu.scss
@@ -5,10 +5,6 @@
 .navbar {
     align-content: flex-start;
 
-    form {
-        flex: 1 1 100%;
-    }
-
     .form-control {
         color: $navbar-dark-active-color;
         background-color: rgba($white, .02);
@@ -33,6 +29,7 @@
 }
 
 .navbar-body-search {
+    flex: 1 1 100%;
     order: 2;
 }
 
@@ -49,18 +46,16 @@
 }
 
 @include media-breakpoint-up(md) {
-    .navbar-expand-md {
-        form {
-            flex-basis: auto;
-        }
-    }
-
     .navbar-body-main-open {
         height: auto;
     }
 
     .navbar-bar {
         flex-grow: 0;
+    }
+
+    .navbar-body-search {
+        flex-basis: auto;
     }
 
     .navbar-body-main {

--- a/assets/scss/05-components/the-header-menu.scss
+++ b/assets/scss/05-components/the-header-menu.scss
@@ -3,6 +3,8 @@
 @import "~bootstrap/scss/navbar";
 
 .navbar {
+    align-content: flex-start;
+
     form {
         flex: 1 1 100%;
     }
@@ -19,6 +21,10 @@
     }
 }
 
+.navbar-body-main-open {
+    height: 100vh;
+}
+
 .navbar-brand {
     order: 1;
 }
@@ -32,17 +38,13 @@
 }
 
 .navbar-body-main {
-    position: absolute;
-    top: 100%;
-    right: 0;
-    left: 0;
     display: none;
     order: 4;
     padding-right: $navbar-padding-x;
     padding-left: $navbar-padding-x;
     background-color: $dark;
 
-    &.show {
+    .navbar-body-main-open & {
         display: block;
     }
 }
@@ -52,6 +54,10 @@
         form {
             flex-basis: auto;
         }
+    }
+
+    .navbar-body-main-open {
+        height: auto;
     }
 
     .navbar-body-main {

--- a/assets/scss/05-components/the-header-menu.scss
+++ b/assets/scss/05-components/the-header-menu.scss
@@ -31,7 +31,9 @@
     .navbar-body-search {
         // empty for now
     }
+}
 
+.navbar-expand-md {
     @include media-breakpoint-up(md) {
         form {
             flex-basis: auto;

--- a/assets/scss/05-components/the-header-menu.scss
+++ b/assets/scss/05-components/the-header-menu.scss
@@ -19,12 +19,25 @@
     }
 }
 
+.navbar-brand {
+    order: 1;
+}
+
+.navbar-toggler {
+    order: 2;
+}
+
+.navbar-body-search {
+    order: 3;
+}
+
 .navbar-body-main {
     position: absolute;
     top: 100%;
     right: 0;
     left: 0;
     display: none;
+    order: 4;
     padding-right: $navbar-padding-x;
     padding-left: $navbar-padding-x;
     background-color: $dark;
@@ -34,26 +47,16 @@
     }
 }
 
-.navbar-body-search {
-    // empty for now
-}
-
 .navbar-expand-md {
     @include media-breakpoint-up(md) {
         form {
             flex-basis: auto;
-            order: 2;
-        }
-
-        .navbar-brand {
-            order: 1;
         }
 
         .navbar-body-main {
             position: static;
             display: block;
             flex-grow: 0;
-            order: 3;
             padding-right: 0;
             padding-left: 0;
             background-color: transparent;

--- a/assets/scss/05-components/the-header-menu.scss
+++ b/assets/scss/05-components/the-header-menu.scss
@@ -17,20 +17,20 @@
             box-shadow: none;
         }
     }
+}
 
-    .navbar-body-main {
-        position: absolute;
-        top: 100%;
-        right: 0;
-        left: 0;
-        padding-right: $navbar-padding-x;
-        padding-left: $navbar-padding-x;
-        background-color: $dark;
-    }
+.navbar-body-main {
+    position: absolute;
+    top: 100%;
+    right: 0;
+    left: 0;
+    padding-right: $navbar-padding-x;
+    padding-left: $navbar-padding-x;
+    background-color: $dark;
+}
 
-    .navbar-body-search {
-        // empty for now
-    }
+.navbar-body-search {
+    // empty for now
 }
 
 .navbar-expand-md {

--- a/assets/scss/05-components/the-header-menu.scss
+++ b/assets/scss/05-components/the-header-menu.scss
@@ -19,6 +19,11 @@
     }
 
     @include media-breakpoint-up(md) {
+        form {
+            flex-basis: auto;
+            order: 2;
+        }
+
         .navbar-brand {
             order: 1;
         }
@@ -26,11 +31,6 @@
         .navbar-collapse {
             flex-grow: 0;
             order: 3;
-        }
-
-        form {
-            flex-basis: auto;
-            order: 2;
         }
     }
 }

--- a/assets/scss/05-components/the-header-menu.scss
+++ b/assets/scss/05-components/the-header-menu.scss
@@ -37,8 +37,7 @@
     display: none;
     flex-grow: 1;
     order: 3;
-    padding-right: $navbar-padding-x;
-    padding-left: $navbar-padding-x;
+    padding: $navbar-padding-y 0;
     overflow-y: auto;
     background-color: $dark;
 
@@ -70,8 +69,7 @@
         position: static;
         display: block;
         flex-grow: 0;
-        padding-right: 0;
-        padding-left: 0;
+        padding: 0;
         background-color: transparent;
     }
 }

--- a/assets/scss/05-components/the-header-menu.scss
+++ b/assets/scss/05-components/the-header-menu.scss
@@ -18,6 +18,16 @@
         }
     }
 
+    .navbar-collapse {
+        position: absolute;
+        top: 100%;
+        right: 0;
+        left: 0;
+        padding-right: $navbar-padding-x;
+        padding-left: $navbar-padding-x;
+        background-color: $dark;
+    }
+
     @include media-breakpoint-up(md) {
         form {
             flex-basis: auto;
@@ -29,8 +39,12 @@
         }
 
         .navbar-collapse {
+            position: static;
             flex-grow: 0;
             order: 3;
+            padding-right: 0;
+            padding-left: 0;
+            background-color: transparent;
         }
     }
 }

--- a/assets/scss/05-components/the-header-menu.scss
+++ b/assets/scss/05-components/the-header-menu.scss
@@ -24,8 +24,8 @@
         }
 
         .navbar-collapse {
-            order: 3;
             flex-grow: 0;
+            order: 3;
         }
 
         form {

--- a/assets/scss/05-components/the-header-menu.scss
+++ b/assets/scss/05-components/the-header-menu.scss
@@ -18,7 +18,7 @@
         }
     }
 
-    .navbar-collapse {
+    .navbar-body-main {
         position: absolute;
         top: 100%;
         right: 0;
@@ -26,6 +26,10 @@
         padding-right: $navbar-padding-x;
         padding-left: $navbar-padding-x;
         background-color: $dark;
+    }
+
+    .navbar-body-search {
+        // empty for now
     }
 
     @include media-breakpoint-up(md) {
@@ -38,7 +42,7 @@
             order: 1;
         }
 
-        .navbar-collapse {
+        .navbar-body-main {
             position: static;
             flex-grow: 0;
             order: 3;

--- a/assets/scss/05-components/the-header-menu.scss
+++ b/assets/scss/05-components/the-header-menu.scss
@@ -3,7 +3,9 @@
 @import "~bootstrap/scss/navbar";
 
 .navbar {
-    align-content: flex-start;
+    flex-flow: column nowrap;
+    align-items: normal;
+    justify-content: flex-start;
 
     .form-control {
         color: $navbar-dark-active-color;
@@ -23,21 +25,21 @@
 
 .navbar-bar {
     display: flex;
-    flex-grow: 1;
     justify-content: space-between;
     order: 1;
 }
 
 .navbar-body-search {
-    flex: 1 1 100%;
     order: 2;
 }
 
 .navbar-body-main {
     display: none;
+    flex-grow: 1;
     order: 3;
     padding-right: $navbar-padding-x;
     padding-left: $navbar-padding-x;
+    overflow-y: auto;
     background-color: $dark;
 
     .navbar-body-main-open & {
@@ -46,6 +48,12 @@
 }
 
 @include media-breakpoint-up(md) {
+    .navbar {
+        flex-direction: row;
+        align-items: center;
+        justify-content: space-between;
+    }
+
     .navbar-body-main-open {
         height: auto;
     }
@@ -55,7 +63,7 @@
     }
 
     .navbar-body-search {
-        flex-basis: auto;
+        flex-grow: 1;
     }
 
     .navbar-body-main {

--- a/assets/scss/05-components/the-header-menu.scss
+++ b/assets/scss/05-components/the-header-menu.scss
@@ -3,16 +3,34 @@
 @import "~bootstrap/scss/navbar";
 
 .navbar {
-    .form-inline {
-        .form-control {
-            color: $navbar-dark-active-color;
-            background-color: rgba($white, .02);
-            border-color: transparent;
+    form {
+        flex: 1 1 100%;
+    }
 
-            &:focus {
-                background-color: rgba($white, .06);
-                box-shadow: none;
-            }
+    .form-control {
+        color: $navbar-dark-active-color;
+        background-color: rgba($white, .02);
+        border-color: transparent;
+
+        &:focus {
+            background-color: rgba($white, .06);
+            box-shadow: none;
+        }
+    }
+
+    @include media-breakpoint-up(md) {
+        .navbar-brand {
+            order: 1;
+        }
+
+        .navbar-collapse {
+            order: 3;
+            flex-grow: 0;
+        }
+
+        form {
+            flex-basis: auto;
+            order: 2;
         }
     }
 }

--- a/assets/scss/05-components/the-header-menu.scss
+++ b/assets/scss/05-components/the-header-menu.scss
@@ -47,19 +47,19 @@
     }
 }
 
-.navbar-expand-md {
-    @include media-breakpoint-up(md) {
+@include media-breakpoint-up(md) {
+    .navbar-expand-md {
         form {
             flex-basis: auto;
         }
+    }
 
-        .navbar-body-main {
-            position: static;
-            display: block;
-            flex-grow: 0;
-            padding-right: 0;
-            padding-left: 0;
-            background-color: transparent;
-        }
+    .navbar-body-main {
+        position: static;
+        display: block;
+        flex-grow: 0;
+        padding-right: 0;
+        padding-left: 0;
+        background-color: transparent;
     }
 }

--- a/assets/scss/07-trumps/layout-default.scss
+++ b/assets/scss/07-trumps/layout-default.scss
@@ -1,9 +1,8 @@
 @import "../required";
 
-$navbar-height:     $navbar-brand-height + $navbar-brand-padding-y * 2 + $navbar-padding-y * 2;
 $page-padding-y:    map-get($spacers, 4);
 
 .page {
-    padding-top: $navbar-height + $page-padding-y;
+    padding-top: $page-padding-y;
     padding-bottom: $page-padding-y;
 }

--- a/components/TheHeader.vue
+++ b/components/TheHeader.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="app-Header fixed-top">
+    <div class="app-Header sticky-top">
         <the-header-menu />
     </div>
 </template>

--- a/components/TheHeaderMenu.vue
+++ b/components/TheHeaderMenu.vue
@@ -51,6 +51,7 @@
                 type="search"
                 class="form-control form-control-sm"
                 name="s"
+                :value="$route.query.s"
                 placeholder="Caută aici..."
             >
         </form>

--- a/components/TheHeaderMenu.vue
+++ b/components/TheHeaderMenu.vue
@@ -24,7 +24,7 @@
             class="navbar-body-main"
             :class="{ 'show': show.navbarBodyMain }"
         >
-            <ul class="navbar-nav flex-grow-1">
+            <ul class="navbar-nav">
                 <li
                     v-for="item in menu"
                     :key="item.ID"

--- a/components/TheHeaderMenu.vue
+++ b/components/TheHeaderMenu.vue
@@ -11,7 +11,6 @@
         <button
             type="button"
             class="navbar-toggler"
-            :class="{ 'collapsed': navCollapse }"
             aria-controls="navbar-body-main"
             :aria-expanded="navCollapse && 'true' || 'false'"
             aria-label="Toggle navigation"
@@ -20,11 +19,10 @@
             <span class="navbar-toggler-icon" />
         </button>
 
-        <b-collapse
+        <div
             id="navbar-body-main"
-            v-model="navCollapse"
             class="navbar-body-main"
-            is-nav
+            :class="{ 'show': navCollapse }"
         >
             <ul class="navbar-nav flex-grow-1">
                 <li
@@ -42,7 +40,7 @@
                     </nuxt-link>
                 </li>
             </ul>
-        </b-collapse>
+        </div>
 
         <form
             action="/"
@@ -61,16 +59,11 @@
 </template>
 
 <script>
-import { BCollapse } from 'bootstrap-vue';
 import menu from '../store/lazy/menu';
 import { SITE } from '../utils/constants';
 
 export default {
     name: 'TheHeaderMenu',
-
-    components: {
-        BCollapse,
-    },
 
     data: () => ({
         navCollapse: false,

--- a/components/TheHeaderMenu.vue
+++ b/components/TheHeaderMenu.vue
@@ -4,7 +4,7 @@
             :to="'/'"
             class="navbar-brand"
         >
-            Navbar
+            {{ SITE.TITLE }}
         </nuxt-link>
 
         <button
@@ -86,6 +86,10 @@ export default {
         menu() {
             return this.$store.state.ui.menu;
         },
+    },
+
+    beforeMount() {
+        this.SITE = SITE;
     },
 
     methods: {

--- a/components/TheHeaderMenu.vue
+++ b/components/TheHeaderMenu.vue
@@ -3,24 +3,26 @@
         class="navbar navbar-expand-md navbar-dark bg-dark"
         :class="{ 'navbar-body-main-open': show.navbarBodyMain }"
     >
-        <nuxt-link
-            :to="'/'"
-            class="navbar-brand"
-            @click.native="show.navbarBodyMain = false"
-        >
-            {{ SITE.TITLE }}
-        </nuxt-link>
+        <div class="navbar-bar">
+            <nuxt-link
+                :to="'/'"
+                class="navbar-brand"
+                @click.native="show.navbarBodyMain = false"
+            >
+                {{ SITE.TITLE }}
+            </nuxt-link>
 
-        <button
-            type="button"
-            class="navbar-toggler"
-            aria-controls="navbar-body-main"
-            :aria-expanded="show.navbarBodyMain && 'true' || 'false'"
-            aria-label="Toggle navigation"
-            @click="show.navbarBodyMain = !show.navbarBodyMain"
-        >
-            <span class="navbar-toggler-icon" />
-        </button>
+            <button
+                type="button"
+                class="navbar-toggler"
+                aria-controls="navbar-body-main"
+                :aria-expanded="show.navbarBodyMain && 'true' || 'false'"
+                aria-label="Toggle navigation"
+                @click="show.navbarBodyMain = !show.navbarBodyMain"
+            >
+                <span class="navbar-toggler-icon" />
+            </button>
+        </div>
 
         <div
             id="navbar-body-main"

--- a/components/TheHeaderMenu.vue
+++ b/components/TheHeaderMenu.vue
@@ -12,7 +12,7 @@
             type="button"
             class="navbar-toggler"
             :class="{ 'collapsed': navCollapse }"
-            aria-controls="navbar-content"
+            aria-controls="navbar-body-main"
             :aria-expanded="navCollapse && 'true' || 'false'"
             aria-label="Toggle navigation"
             @click="navCollapse = !navCollapse"
@@ -21,8 +21,9 @@
         </button>
 
         <b-collapse
-            id="navbar-content"
+            id="navbar-body-main"
             v-model="navCollapse"
+            class="navbar-body-main"
             is-nav
         >
             <ul class="navbar-nav flex-grow-1">
@@ -45,6 +46,7 @@
 
         <form
             action="/"
+            class="navbar-body-search"
             @submit.prevent="goToSearch($event)"
         >
             <input

--- a/components/TheHeaderMenu.vue
+++ b/components/TheHeaderMenu.vue
@@ -107,12 +107,6 @@ export default {
 
             return output;
         },
-        menuItemActive(item) {
-            const menuItemTo = this.menuItemTo(item);
-            const itemPath = (typeof menuItemTo === 'string') ? menuItemTo : `/${menuItemTo.params.singleSlug}/`;
-
-            return this.$route.path === itemPath;
-        },
         goToSearch($event) {
             const s = $event.target.elements.s.value;
 

--- a/components/TheHeaderMenu.vue
+++ b/components/TheHeaderMenu.vue
@@ -3,6 +3,7 @@
         <nuxt-link
             :to="'/'"
             class="navbar-brand"
+            @click.native="navCollapse = false"
         >
             {{ SITE.TITLE }}
         </nuxt-link>

--- a/components/TheHeaderMenu.vue
+++ b/components/TheHeaderMenu.vue
@@ -24,16 +24,22 @@
             v-model="navCollapse"
             is-nav
         >
-            <b-navbar-nav class="flex-grow-1">
-                <b-nav-item
+            <ul class="navbar-nav flex-grow-1">
+                <li
                     v-for="item in menu"
                     :key="item.ID"
-                    :to="menuItemTo(item)"
-                    :active="menuItemActive(item)"
+                    class="nav-item"
                 >
-                    {{ item.title }}
-                </b-nav-item>
-            </b-navbar-nav>
+                    <nuxt-link
+                        :to="menuItemTo(item)"
+                        class="nav-link"
+                        exact-active-class="active"
+                        @click.native="navCollapse = false"
+                    >
+                        {{ item.title }}
+                    </nuxt-link>
+                </li>
+            </ul>
         </b-collapse>
 
         <form
@@ -51,10 +57,7 @@
 </template>
 
 <script>
-import {
-    BNavbarNav, BNavItem,
-    BCollapse,
-} from 'bootstrap-vue';
+import { BCollapse } from 'bootstrap-vue';
 import menu from '../store/lazy/menu';
 import { SITE } from '../utils/constants';
 
@@ -62,8 +65,6 @@ export default {
     name: 'TheHeaderMenu',
 
     components: {
-        BNavbarNav,
-        BNavItem,
         BCollapse,
     },
 

--- a/components/TheHeaderMenu.vue
+++ b/components/TheHeaderMenu.vue
@@ -32,7 +32,7 @@
                     class="nav-item"
                 >
                     <nuxt-link
-                        :to="menuItemTo(item)"
+                        :to="item.to"
                         class="nav-link"
                         exact-active-class="active"
                         @click.native="navCollapse = false"
@@ -91,22 +91,6 @@ export default {
     },
 
     methods: {
-        menuItemTo(item) {
-            const url = new URL(item.url, SITE.LINK);
-            let output = url.pathname;
-
-            if (['post', 'page'].includes(item.object)) {
-                output = {
-                    name: 'Single',
-                    params: {
-                        singleSlug: url.pathname.slice(1, -1),
-                        singleType: item.object,
-                    },
-                };
-            }
-
-            return output;
-        },
         goToSearch($event) {
             const s = $event.target.elements.s.value;
 

--- a/components/TheHeaderMenu.vue
+++ b/components/TheHeaderMenu.vue
@@ -3,7 +3,7 @@
         <nuxt-link
             :to="'/'"
             class="navbar-brand"
-            @click.native="navCollapse = false"
+            @click.native="show.navbarBodyMain = false"
         >
             {{ SITE.TITLE }}
         </nuxt-link>
@@ -12,9 +12,9 @@
             type="button"
             class="navbar-toggler"
             aria-controls="navbar-body-main"
-            :aria-expanded="navCollapse && 'true' || 'false'"
+            :aria-expanded="show.navbarBodyMain && 'true' || 'false'"
             aria-label="Toggle navigation"
-            @click="navCollapse = !navCollapse"
+            @click="show.navbarBodyMain = !show.navbarBodyMain"
         >
             <span class="navbar-toggler-icon" />
         </button>
@@ -22,7 +22,7 @@
         <div
             id="navbar-body-main"
             class="navbar-body-main"
-            :class="{ 'show': navCollapse }"
+            :class="{ 'show': show.navbarBodyMain }"
         >
             <ul class="navbar-nav flex-grow-1">
                 <li
@@ -34,7 +34,7 @@
                         :to="item.to"
                         class="nav-link"
                         exact-active-class="active"
-                        @click.native="navCollapse = false"
+                        @click.native="show.navbarBodyMain = false"
                     >
                         {{ item.title }}
                     </nuxt-link>
@@ -66,7 +66,9 @@ export default {
     name: 'TheHeaderMenu',
 
     data: () => ({
-        navCollapse: false,
+        show: {
+            navbarBodyMain: false,
+        },
     }),
 
     async fetch() {
@@ -92,7 +94,7 @@ export default {
             if (!s) return;
 
             this.$router.push({ path: '/', query: { s } });
-            this.navCollapse = false;
+            this.show.navbarBodyMain = false;
         },
     },
 };

--- a/components/TheHeaderMenu.vue
+++ b/components/TheHeaderMenu.vue
@@ -1,5 +1,8 @@
 <template>
-    <nav class="navbar navbar-expand-md navbar-dark bg-dark">
+    <nav
+        class="navbar navbar-expand-md navbar-dark bg-dark"
+        :class="{ 'navbar-body-main-open': show.navbarBodyMain }"
+    >
         <nuxt-link
             :to="'/'"
             class="navbar-brand"
@@ -22,7 +25,6 @@
         <div
             id="navbar-body-main"
             class="navbar-body-main"
-            :class="{ 'show': show.navbarBodyMain }"
         >
             <ul class="navbar-nav">
                 <li

--- a/components/TheHeaderMenu.vue
+++ b/components/TheHeaderMenu.vue
@@ -25,20 +25,6 @@
             is-nav
         >
             <b-navbar-nav class="flex-grow-1">
-                <b-nav-form
-                    action="/"
-                    class="mr-md-auto order-last order-md-first py-3 py-md-0"
-                    form-class="flex-grow-1"
-                    @submit.prevent="goToSearch($event)"
-                >
-                    <b-form-input
-                        type="search"
-                        size="sm"
-                        class="flex-grow-1"
-                        name="s"
-                        placeholder="Caută aici..."
-                    />
-                </b-nav-form>
                 <b-nav-item
                     v-for="item in menu"
                     :key="item.ID"
@@ -49,14 +35,25 @@
                 </b-nav-item>
             </b-navbar-nav>
         </b-collapse>
+
+        <form
+            action="/"
+            @submit.prevent="goToSearch($event)"
+        >
+            <input
+                type="search"
+                class="form-control form-control-sm"
+                name="s"
+                placeholder="Caută aici..."
+            >
+        </form>
     </nav>
 </template>
 
 <script>
 import {
-    BNavbarNav, BNavForm, BNavItem,
+    BNavbarNav, BNavItem,
     BCollapse,
-    BFormInput,
 } from 'bootstrap-vue';
 import menu from '../store/lazy/menu';
 import { SITE } from '../utils/constants';
@@ -66,10 +63,8 @@ export default {
 
     components: {
         BNavbarNav,
-        BNavForm,
         BNavItem,
         BCollapse,
-        BFormInput,
     },
 
     data: () => ({

--- a/services/menu.js
+++ b/services/menu.js
@@ -1,4 +1,5 @@
 import { ENDPOINTS } from '../utils/constants';
+import { menu } from '~/utils/adaptors';
 
 const fetchMenu = async (payload) => {
     try {
@@ -7,7 +8,7 @@ const fetchMenu = async (payload) => {
             url: ENDPOINTS.MENU,
         });
 
-        return response.data;
+        return menu(response.data);
     } catch (error) {
         throw error.response;
     }

--- a/services/menu.js
+++ b/services/menu.js
@@ -1,4 +1,4 @@
-import { ENDPOINTS } from '../utils/constants';
+import { ENDPOINTS } from '~/utils/constants';
 import { menu } from '~/utils/adaptors';
 
 const fetchMenu = async (payload) => {

--- a/utils/adaptors/index.js
+++ b/utils/adaptors/index.js
@@ -1,5 +1,7 @@
 export { default as head } from './head';
 
+export { default as menu } from './menu';
+
 export { default as pageCategory } from './page-category';
 export { default as pageSinglePost } from './page-single-post';
 export { default as pageSinglePage } from './page-single-page';

--- a/utils/adaptors/menu.js
+++ b/utils/adaptors/menu.js
@@ -1,7 +1,26 @@
+import { SITE } from '~/utils/constants';
+
+const to = ({ url, object }) => {
+    const newUrl = new URL(url, SITE.LINK);
+    let output = newUrl.pathname;
+
+    if (['post', 'page'].includes(object)) {
+        output = {
+            name: 'Single',
+            params: {
+                singleSlug: newUrl.pathname.slice(1, -1),
+                singleType: object,
+            },
+        };
+    }
+
+    return output;
+};
+
 const item = ({
     ID, title, url, object,
 }) => ({
-    ID, title, url, object,
+    ID, title, to: to({ url, object }),
 });
 
 export default (payload) => payload.map((payloadItem) => item(payloadItem));

--- a/utils/adaptors/menu.js
+++ b/utils/adaptors/menu.js
@@ -1,1 +1,7 @@
-export default (payload) => payload;
+const item = ({
+    ID, title, url, object,
+}) => ({
+    ID, title, url, object,
+});
+
+export default (payload) => payload.map((payloadItem) => item(payloadItem));

--- a/utils/adaptors/menu.js
+++ b/utils/adaptors/menu.js
@@ -1,0 +1,1 @@
+export default (payload) => payload;


### PR DESCRIPTION
- adds cabral.ro text
- isolates menu from search input
- remove bootstrap-vue components / we'll migrate to bootstrap 5 in the near future
- makes header sticky
- applies [wordrpess api filter _fields](https://developer.wordpress.org/rest-api/using-the-rest-api/global-parameters/#_fields) and adds menu data adaptor
- makes mobile menu open in full width & height