### PR TITLE
feature: clean up some spacings on single layout page

### DIFF
--- a/assets/scss/04-objects/_box.scss
+++ b/assets/scss/04-objects/_box.scss
@@ -1,0 +1,13 @@
+.box {
+    > * {
+        margin-bottom: 0;
+    }
+
+    > * + * {
+        margin-top: $spacer;
+    }
+}
+
+.box-title {
+    font-size: $h4-font-size;
+}

--- a/assets/scss/04-objects/_index.scss
+++ b/assets/scss/04-objects/_index.scss
@@ -4,3 +4,4 @@
 @import "~bootstrap/scss/spinners";
 
 @import "./animations";
+@import "./box";

--- a/assets/scss/05-components/comments-list.scss
+++ b/assets/scss/05-components/comments-list.scss
@@ -18,5 +18,13 @@
         > * + * {
             border-top: $border-width solid $border-color;
         }
+
+        &:last-child {
+            display: none;
+        }
+    }
+
+    .loading & > li:last-child {
+        display: block;
     }
 }

--- a/assets/scss/05-components/gallery-tiled.scss
+++ b/assets/scss/05-components/gallery-tiled.scss
@@ -1,0 +1,97 @@
+// This is a jetpack component
+// See https://c0.wp.com/p/jetpack/10.8/css/jetpack.css
+
+.tiled-gallery {
+    clear: both;
+    margin: 0 0 20px;
+    overflow: hidden;
+}
+
+.tiled-gallery img {
+    margin: 2px !important;
+}
+
+.tiled-gallery .gallery-group {
+    position: relative;
+    float: left;
+}
+
+.tiled-gallery .tiled-gallery-item {
+    position: relative;
+    float: left;
+    width: inherit;
+    margin: 0;
+}
+
+.tiled-gallery .gallery-row {
+    overflow: hidden;
+}
+
+.tiled-gallery .tiled-gallery-item a {
+    width: auto;
+    margin: 0;
+    padding: 0;
+    color: inherit;
+    text-decoration: none;
+    background: 0 0;
+    border: none;
+}
+
+.tiled-gallery .tiled-gallery-item img,
+.tiled-gallery .tiled-gallery-item img:hover {
+    max-width: 100%;
+    padding: 0;
+    vertical-align: middle;
+    background: 0 0;
+    border: none;
+    box-shadow: none;
+}
+
+.tiled-gallery-caption {
+    position: absolute;
+    bottom: 0;
+    width: 100%;
+    padding: 10px 0;
+    overflow: hidden;
+    color: #333;
+    font-weight: 400;
+    font-size: 13px;
+    white-space: nowrap;
+    text-indent: 10px;
+    text-overflow: ellipsis;
+    background: #f0f0f1;
+    background: rgba(255, 255, 255, .8);
+}
+
+.tiled-gallery .tiled-gallery-item-small .tiled-gallery-caption {
+    font-size: 11px;
+}
+
+.widget-gallery .tiled-gallery-unresized {
+    height: 0;
+    overflow: hidden;
+    visibility: hidden;
+}
+
+.tiled-gallery .tiled-gallery-item img.grayscale {
+    position: absolute;
+    top: 0;
+    left: 0;
+}
+
+.tiled-gallery .tiled-gallery-item img.grayscale:hover {
+    opacity: 0;
+}
+
+.tiled-gallery.type-circle .tiled-gallery-item img {
+    object-fit: cover;
+    border-radius: 50% !important;
+}
+
+.tiled-gallery.type-circle .tiled-gallery-caption {
+    display: none;
+}
+
+.tiled-gallery.type-square .tiled-gallery-item img {
+    object-fit: cover;
+}

--- a/assets/scss/05-components/layout-hero.scss
+++ b/assets/scss/05-components/layout-hero.scss
@@ -1,0 +1,22 @@
+@import "../required";
+
+.layout-hero {
+    position: relative;
+    z-index: -1;
+    height: 65vh;
+    overflow: hidden;
+    background-color: $black;
+
+    img {
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        width: auto !important;
+        min-width: 100%;
+        max-width: none;
+        height: auto !important;
+        min-height: 100%;
+        max-height: none;
+        transform: translate(-50%, -50%);
+    }
+}

--- a/assets/scss/05-components/list-item-info.scss
+++ b/assets/scss/05-components/list-item-info.scss
@@ -3,8 +3,13 @@
 .list-item-info {
     @include list-unstyled;
     display: flex;
-    flex-wrap: wrap;
+    overflow-x: scroll;
     font-size: $font-size-sm;
+    white-space: nowrap;
+
+    &::-webkit-scrollbar {
+        display: none;
+    }
 
     &,
     a {

--- a/assets/scss/05-components/list-share.scss
+++ b/assets/scss/05-components/list-share.scss
@@ -3,7 +3,6 @@
 .list-share {
     @include list-unstyled;
     display: flex;
-    flex-wrap: wrap;
     font-size: $font-size-sm;
 
     li + li {

--- a/assets/scss/05-components/nav-categories.scss
+++ b/assets/scss/05-components/nav-categories.scss
@@ -1,7 +1,9 @@
 .nav-categories {
+    margin-bottom: -$spacer;
+
     .nav-item {
         display: inline-block;
-        margin: $spacer $spacer 0 0;
+        margin: 0 $spacer $spacer 0;
     }
 
     .nav-link {

--- a/assets/scss/05-components/the-header-menu.scss
+++ b/assets/scss/05-components/the-header-menu.scss
@@ -41,6 +41,10 @@
     overflow-y: auto;
     background-color: $dark;
 
+    > * {
+        margin-bottom: $spacer;
+    }
+
     .navbar-body-main-open & {
         display: block;
     }
@@ -75,6 +79,10 @@
         flex-grow: 0;
         padding: 0;
         background-color: transparent;
+
+        > * {
+            margin-bottom: 0;
+        }
     }
 }
 

--- a/assets/scss/06-utilities/_index.scss
+++ b/assets/scss/06-utilities/_index.scss
@@ -1,3 +1,5 @@
 @import "~bootstrap/scss/utilities";
 
 @import "~bootstrap-vue/src/utilities";
+
+@import "scroll";

--- a/assets/scss/06-utilities/_index.scss
+++ b/assets/scss/06-utilities/_index.scss
@@ -3,3 +3,4 @@
 @import "~bootstrap-vue/src/utilities";
 
 @import "scroll";
+@import "width";

--- a/assets/scss/06-utilities/_scroll.scss
+++ b/assets/scss/06-utilities/_scroll.scss
@@ -1,0 +1,8 @@
+.scroll-x {
+    overflow-x: auto;
+    white-space: nowrap;
+}
+
+.scroll-hide-bar::-webkit-scrollbar {
+    display: none;
+}

--- a/assets/scss/06-utilities/_width.scss
+++ b/assets/scss/06-utilities/_width.scss
@@ -1,0 +1,5 @@
+.w-100vw {
+    width: 100vw;
+    margin-left: 50%;
+    transform: translateX(-50%);
+}

--- a/assets/scss/07-trumps/layout-default.scss
+++ b/assets/scss/07-trumps/layout-default.scss
@@ -2,27 +2,6 @@
 
 $page-padding:      map-get($spacers, 4);
 
-.layout-hero {
-    position: relative;
-    z-index: -1;
-    height: 65vh;
-    overflow: hidden;
-    background-color: $black;
-
-    img {
-        position: absolute;
-        top: 50%;
-        left: 50%;
-        width: auto !important;
-        min-width: 100%;
-        max-width: none;
-        height: auto !important;
-        min-height: 100%;
-        max-height: none;
-        transform: translate(-50%, -50%);
-    }
-}
-
 .layout-default {
     .sidebar {
         padding-top: $page-padding;

--- a/assets/scss/07-trumps/layout-default.scss
+++ b/assets/scss/07-trumps/layout-default.scss
@@ -2,6 +2,27 @@
 
 $page-padding:      map-get($spacers, 4);
 
+.layout-hero {
+    position: relative;
+    z-index: -1;
+    height: 65vh;
+    overflow: hidden;
+    background-color: $black;
+
+    img {
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        width: auto !important;
+        min-width: 100%;
+        max-width: none;
+        height: auto !important;
+        min-height: 100%;
+        max-height: none;
+        transform: translate(-50%, -50%);
+    }
+}
+
 .layout-default {
     .sidebar {
         padding-top: $page-padding;

--- a/assets/scss/07-trumps/layout-default.scss
+++ b/assets/scss/07-trumps/layout-default.scss
@@ -5,7 +5,6 @@ $page-padding:      map-get($spacers, 4);
 .layout-default {
     .sidebar {
         padding-top: $page-padding;
-        padding-right: $page-padding;
         padding-bottom: $page-padding;
 
         > * {

--- a/assets/scss/07-trumps/layout-default.scss
+++ b/assets/scss/07-trumps/layout-default.scss
@@ -7,6 +7,10 @@ $page-padding:      map-get($spacers, 4);
         padding-top: $page-padding;
         padding-right: $page-padding;
         padding-bottom: $page-padding;
+
+        > * {
+            margin-bottom: $spacer;
+        }
     }
     .page {
         position: static;

--- a/assets/scss/07-trumps/layout-default.scss
+++ b/assets/scss/07-trumps/layout-default.scss
@@ -3,7 +3,7 @@
 $page-padding:      map-get($spacers, 4);
 
 .layout-default {
-    .sidebar-left {
+    .sidebar {
         padding-top: $page-padding;
         padding-right: $page-padding;
         padding-bottom: $page-padding;
@@ -16,10 +16,5 @@ $page-padding:      map-get($spacers, 4);
         position: static;
         padding-top: $page-padding;
         padding-bottom: $page-padding;
-    }
-    .sidebar-right {
-        padding-top: $page-padding;
-        padding-bottom: $page-padding;
-        padding-left: $page-padding;
     }
 }

--- a/assets/scss/07-trumps/page-single.scss
+++ b/assets/scss/07-trumps/page-single.scss
@@ -75,7 +75,7 @@
         .wp-block-image,
         .wp-block-embed,
         .embed-youtube {
-            margin-right: -(map-get($spacers, 5) / 2);
+            margin-right: -180px;
             margin-left: -(map-get($spacers, 5) / 2);
         }
     }

--- a/assets/scss/07-trumps/page-single.scss
+++ b/assets/scss/07-trumps/page-single.scss
@@ -40,6 +40,12 @@
     }
 }
 
+.entry-body {
+    > * {
+        margin-bottom: map-get($spacers, 5);
+    }
+}
+
 .entry-content {
     font-size: $font-size-lg;
     font-family: $font-family-serif;

--- a/assets/scss/07-trumps/page-single.scss
+++ b/assets/scss/07-trumps/page-single.scss
@@ -25,18 +25,16 @@
 }
 
 .entry-img-hero + .entry-body {
-    width: auto;
     margin: #{50vh} -($grid-gutter-width / 2) 0 -($grid-gutter-width / 2);
     padding: $grid-gutter-width / 2;
     background-color: $body-bg;
     border-top-left-radius: $border-radius-lg;
     border-top-right-radius: $border-radius-lg;
 
-    @include media-breakpoint-up(md) {
-        margin-right: 0;
-        margin-left: 0;
-        padding: map-get($spacers, 5);
-        border-radius: 0;
+    @include media-breakpoint-up(sm) {
+        margin-right: -$grid-gutter-width;
+        margin-left: -$grid-gutter-width;
+        padding: $grid-gutter-width $grid-gutter-width 0 $grid-gutter-width;
     }
 }
 

--- a/assets/scss/07-trumps/page-single.scss
+++ b/assets/scss/07-trumps/page-single.scss
@@ -1,27 +1,6 @@
 @import "../required";
 
-.entry-img-hero {
-    position: relative;
-    z-index: -1;
-    height: 65vh;
-    overflow: hidden;
-    background-color: $black;
-
-    img {
-        position: absolute;
-        top: 50%;
-        left: 50%;
-        width: auto !important;
-        min-width: 100%;
-        max-width: none;
-        height: auto !important;
-        min-height: 100%;
-        max-height: none;
-        transform: translate(-50%, -50%);
-    }
-}
-
-.entry-img-hero + .container-fluid .entry-body {
+.layout-hero + .container-fluid .entry-body {
     margin: (-100px) (-($grid-gutter-width / 2)) 0 (-($grid-gutter-width / 2));
     padding: $grid-gutter-width / 2;
     background-color: $body-bg;

--- a/assets/scss/07-trumps/page-single.scss
+++ b/assets/scss/07-trumps/page-single.scss
@@ -2,7 +2,7 @@
 
 .entry-img-hero {
     position: absolute;
-    top: 50px;
+    top: 56px;
     right: 0;
     left: 0;
     z-index: -1;
@@ -210,8 +210,7 @@
 }
 
 .body-single-hero {
-    .sidebar-left,
-    .sidebar-right {
-        padding-top: 65vh;
+    .sidebar {
+        padding-top: calc(65vh + #{$grid-gutter-width / 2});
     }
 }

--- a/assets/scss/07-trumps/page-single.scss
+++ b/assets/scss/07-trumps/page-single.scss
@@ -27,7 +27,7 @@
 .entry-img-hero + .entry-body {
     width: auto;
     margin: #{50vh} -($grid-gutter-width / 2) 0 -($grid-gutter-width / 2);
-    padding: $grid-gutter-width;
+    padding: $grid-gutter-width / 2;
     background-color: $body-bg;
     border-top-left-radius: $border-radius-lg;
     border-top-right-radius: $border-radius-lg;

--- a/assets/scss/07-trumps/page-single.scss
+++ b/assets/scss/07-trumps/page-single.scss
@@ -24,7 +24,7 @@
     }
 }
 
-.entry-img-hero + .container-fluid {
+.entry-img-hero + .entry-body {
     width: auto;
     margin: #{50vh} -($grid-gutter-width / 2) 0 -($grid-gutter-width / 2);
     padding: $grid-gutter-width;

--- a/assets/scss/07-trumps/page-single.scss
+++ b/assets/scss/07-trumps/page-single.scss
@@ -1,10 +1,7 @@
 @import "../required";
 
 .entry-img-hero {
-    position: absolute;
-    top: 56px;
-    right: 0;
-    left: 0;
+    position: relative;
     z-index: -1;
     height: 65vh;
     overflow: hidden;
@@ -24,8 +21,8 @@
     }
 }
 
-.entry-img-hero + .entry-body {
-    margin: #{50vh} -($grid-gutter-width / 2) 0 -($grid-gutter-width / 2);
+.entry-img-hero + .container-fluid .entry-body {
+    margin: (-100px) (-($grid-gutter-width / 2)) 0 (-($grid-gutter-width / 2));
     padding: $grid-gutter-width / 2;
     background-color: $body-bg;
     border-top-left-radius: $border-radius-lg;
@@ -210,10 +207,4 @@
 .alignright {
     float: right;
     margin-left: $spacer;
-}
-
-.body-single-hero {
-    .sidebar {
-        padding-top: calc(65vh + #{$grid-gutter-width / 2});
-    }
 }

--- a/assets/scss/07-trumps/page-single.scss
+++ b/assets/scss/07-trumps/page-single.scss
@@ -46,6 +46,10 @@
     }
 }
 
+.entry-header {
+    margin-bottom: $spacer;
+}
+
 .entry-content {
     font-size: $font-size-lg;
     font-family: $font-family-serif;
@@ -85,11 +89,6 @@
             margin-left: -(map-get($spacers, 5) / 2);
         }
     }
-}
-
-// content
-.entry-title {
-    margin-bottom: map-get($spacers, 4);
 }
 
 // content childs

--- a/components/CommentsList.vue
+++ b/components/CommentsList.vue
@@ -41,10 +41,7 @@
                     }"
                 />
             </li>
-            <li
-                v-if="loading"
-                class="py-4 text-center"
-            >
+            <li class="py-4 text-center">
                 <b-spinner variant="warning" label="Loading..." />
             </li>
         </ul>
@@ -71,7 +68,6 @@ export default {
     },
 
     props: {
-        loading: Boolean,
         comments: {
             type: Object,
             default: () => ({}),

--- a/components/CommentsList.vue
+++ b/components/CommentsList.vue
@@ -1,6 +1,8 @@
 <template>
-    <div>
-        <h3>Comentarii</h3>
+    <div class="box">
+        <h3 class="box-title">
+            Comentarii
+        </h3>
 
         <comments-list-form :data="{ singleId }" />
 

--- a/components/CommentsList.vue
+++ b/components/CommentsList.vue
@@ -52,6 +52,7 @@
 </template>
 
 <script>
+import { ObserveVisibility } from 'vue-observe-visibility';
 import { BSpinner } from 'bootstrap-vue';
 import CommentsListComment from './CommentsListComment.vue';
 import CommentsListForm from './CommentsListForm.vue';
@@ -63,6 +64,10 @@ export default {
         BSpinner,
         CommentsListComment,
         CommentsListForm,
+    },
+
+    directives: {
+        ObserveVisibility,
     },
 
     props: {

--- a/components/CommentsListComment.vue
+++ b/components/CommentsListComment.vue
@@ -1,7 +1,19 @@
 <template>
     <div class="comment">
         <div class="comment-header">
-            <div v-html="printAuthor(comment)/* eslint-disable-line vue/no-v-html */" />
+            <template v-if="comment.author.node">
+                <template v-if="!comment.author.node.url">
+                    {{ comment.author.node.name }}
+                </template>
+                <a
+                    v-else
+                    :href="comment.author.node.url"
+                    target="_blank"
+                    rel="external nofollow ugc"
+                >
+                    {{ comment.author.node.name }}
+                </a>
+            </template>
             <list-item-info
                 :data="[{
                     icon: 'date',
@@ -30,15 +42,6 @@ export default {
         comment: {
             type: Object,
             required: true,
-        },
-    },
-
-    methods: {
-        printAuthor(comment) {
-            let output = comment.author.node.name;
-            if (comment.author.node.url) output = `<a href="${comment.author.node.url}" target="_blank">${output}</a>`;
-
-            return output;
         },
     },
 };

--- a/components/ListRelated.vue
+++ b/components/ListRelated.vue
@@ -1,20 +1,24 @@
 <template>
-    <div>
-        <h3>Pe aceeași temă</h3>
+    <div class="box">
+        <h3 class="box-title">
+            Pe aceeași temă
+        </h3>
 
-        <div class="row row-related">
-            <div
-                v-for="(post, index) in data"
-                :key="`related-${index}`"
-                class="col-sm-4 mb-3 mb-sm-0"
-            >
-                <base-item-post
-                    :post="post"
-                    :img="post.featuredMedia"
-                    :title="post.title"
-                    :slug="post.slug"
-                    :body-text="post.excerpt"
-                />
+        <div class="box-body">
+            <div class="row row-related">
+                <div
+                    v-for="(post, index) in data"
+                    :key="`related-${index}`"
+                    class="col-sm-4 mb-3 mb-sm-0"
+                >
+                    <base-item-post
+                        :post="post"
+                        :img="post.featuredMedia"
+                        :title="post.title"
+                        :slug="post.slug"
+                        :body-text="post.excerpt"
+                    />
+                </div>
             </div>
         </div>
     </div>

--- a/components/ListRelated.vue
+++ b/components/ListRelated.vue
@@ -1,23 +1,25 @@
 <template>
-    <div class="box">
-        <h3 class="box-title">
-            Pe aceeași temă
-        </h3>
+    <div class="w-100vw p-3 p-lg-5 bg-light">
+        <div class="box">
+            <h3 class="box-title">
+                Pe aceeași temă
+            </h3>
 
-        <div class="box-body">
-            <div class="row row-related">
-                <div
-                    v-for="(post, index) in data"
-                    :key="`related-${index}`"
-                    class="col-sm-4 mb-3 mb-sm-0"
-                >
-                    <base-item-post
-                        :post="post"
-                        :img="post.featuredMedia"
-                        :title="post.title"
-                        :slug="post.slug"
-                        :body-text="post.excerpt"
-                    />
+            <div class="box-body">
+                <div class="row row-related">
+                    <div
+                        v-for="(post, index) in data"
+                        :key="`related-${index}`"
+                        class="col-sm-4 mb-3 mb-sm-0"
+                    >
+                        <base-item-post
+                            :post="post"
+                            :img="post.featuredMedia"
+                            :title="post.title"
+                            :slug="post.slug"
+                            :body-text="post.excerpt"
+                        />
+                    </div>
                 </div>
             </div>
         </div>

--- a/components/layout-hero.vue
+++ b/components/layout-hero.vue
@@ -1,0 +1,23 @@
+<template>
+    <div
+        class="layout-hero"
+        v-html="html/* eslint-disable-line vue/no-v-html */"
+    />
+</template>
+
+<script>
+export default {
+    name: 'LayoutHero',
+
+    props: {
+        html: {
+            type: String,
+            default: '',
+        },
+    },
+};
+</script>
+
+<style lang="scss">
+@import "~/assets/scss/05-components/layout-hero";
+</style>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,6 +1,11 @@
 <template>
     <div class="layout-default">
         <the-header />
+        <div
+            v-if="data.main.featuredMedia"
+            class="entry-img-hero"
+            v-html="data.main.featuredMedia/* eslint-disable-line vue/no-v-html */"
+        />
         <div class="container-fluid">
             <div class="row">
                 <div class="d-none d-xl-block col-xl-3 sidebar">
@@ -20,6 +25,16 @@
         <lazy-the-notifications />
     </div>
 </template>
+
+<script>
+import { currentPage } from '~/mixins';
+
+export default {
+    mixins: [
+        currentPage,
+    ],
+};
+</script>
 
 <style lang="scss">
 @import "~/assets/scss/07-trumps/layout-default";

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,10 +1,9 @@
 <template>
     <div class="layout-default">
         <the-header />
-        <div
+        <layout-hero
             v-if="$route.name === 'Single' && data.main.featuredMedia"
-            class="layout-hero"
-            v-html="data.main.featuredMedia/* eslint-disable-line vue/no-v-html */"
+            :html="data.main.featuredMedia"
         />
         <div class="container-fluid">
             <div class="row">
@@ -28,8 +27,13 @@
 
 <script>
 import { currentPage } from '~/mixins';
+import LayoutHero from '~/components/layout-hero.vue';
 
 export default {
+    components: {
+        LayoutHero,
+    },
+
     mixins: [
         currentPage,
     ],

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -2,8 +2,8 @@
     <div class="layout-default">
         <the-header />
         <div
-            v-if="data.main.featuredMedia"
-            class="entry-img-hero"
+            v-if="$route.name === 'Single' && data.main.featuredMedia"
+            class="layout-hero"
             v-html="data.main.featuredMedia/* eslint-disable-line vue/no-v-html */"
         />
         <div class="container-fluid">

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -2,11 +2,19 @@
     <div class="layout-default">
         <the-header />
         <div class="container-fluid">
-            <div class="row no-gutters">
+            <div class="row">
                 <div class="d-none d-xl-block col-xl-3 sidebar">
                     <portal-target name="widget-categories" />
                 </div>
-                <Nuxt class="col-12 col-xl-6 page" />
+                <Nuxt
+                    class="page"
+                    :class="[
+                        'col-12',
+                        'offset-sm-1', 'col-sm-10',
+                        'offset-lg-2', 'col-lg-8',
+                        'offset-xl-0', 'col-xl-6',
+                    ]"
+                />
             </div>
         </div>
         <lazy-the-notifications />

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -3,11 +3,10 @@
         <the-header />
         <div class="container-fluid">
             <div class="row no-gutters">
-                <div class="d-none d-xl-block col-xl-3 sidebar-left">
+                <div class="d-none d-xl-block col-xl-3 sidebar">
                     <portal-target name="widget-categories" />
                 </div>
                 <Nuxt class="col-12 col-xl-6 page" />
-                <div class="d-none d-xl-block col-xl-3 sidebar-right" />
             </div>
         </div>
         <lazy-the-notifications />

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -10,6 +10,7 @@ export default {
         ],
     },
     plugins: [
+        '~/plugins/store-utils.js',
         '~/plugins/router-hooks.js',
         '~/plugins/filters.js',
         '~/plugins/vue-lazysizes.client.js',

--- a/pages/Archive.vue
+++ b/pages/Archive.vue
@@ -24,6 +24,13 @@ import dataHead from '~/store/lazy/data-head';
 import { currentPage } from '~/mixins';
 import PostsList from '~/components/PostsList.vue';
 
+const registerModules = (store) => {
+    store.$registerModules([
+        { name: ['data', 'dataListing'], imported: dataListing, preserveStateCheck: true },
+        { name: ['data', 'dataHead'], imported: dataHead, preserveStateCheck: true },
+    ]);
+};
+
 export default {
     components: {
         PostsList,
@@ -34,12 +41,7 @@ export default {
     ],
 
     async asyncData({ store, route }) {
-        if (!store.hasModule(['data', 'dataListing'])) {
-            store.registerModule(['data', 'dataListing'], dataListing, { preserveState: true });
-        }
-        if (!store.hasModule(['data', 'dataHead'])) {
-            store.registerModule(['data', 'dataHead'], dataHead, { preserveState: true });
-        }
+        registerModules(store);
 
         const { pathMatch, slug } = route.params;
         const [pageSlug, pageNumber] = slug.split('/page/');
@@ -62,8 +64,8 @@ export default {
 
     watchQuery: ['s'],
 
-    beforeDestroy() {
-        this.$store.unregisterModule(['data', 'dataListing']);
+    mounted() {
+        registerModules(this.$store);
     },
 };
 </script>

--- a/pages/Home.vue
+++ b/pages/Home.vue
@@ -19,6 +19,13 @@ import dataHead from '~/store/lazy/data-head';
 import { currentPage } from '~/mixins';
 import PostsList from '~/components/PostsList.vue';
 
+const registerModules = (store) => {
+    store.$registerModules([
+        { name: ['data', 'dataListing'], imported: dataListing, preserveStateCheck: true },
+        { name: ['data', 'dataHead'], imported: dataHead, preserveStateCheck: true },
+    ]);
+};
+
 export default {
     components: {
         PostsList,
@@ -29,12 +36,7 @@ export default {
     ],
 
     async asyncData({ store, route }) {
-        if (!store.hasModule(['data', 'dataListing'])) {
-            store.registerModule(['data', 'dataListing'], dataListing, { preserveState: true });
-        }
-        if (!store.hasModule(['data', 'dataHead'])) {
-            store.registerModule(['data', 'dataHead'], dataHead, { preserveState: true });
-        }
+        registerModules(store);
 
         const { id: pageNumber } = route.params;
         const pageS = route.query.s;
@@ -55,8 +57,8 @@ export default {
 
     watchQuery: ['s'],
 
-    beforeDestroy() {
-        this.$store.unregisterModule(['data', 'dataListing']);
+    mounted() {
+        registerModules(this.$store);
     },
 
     methods: {

--- a/pages/Single.vue
+++ b/pages/Single.vue
@@ -32,11 +32,10 @@
                 :data="data.related"
             />
             <div
-                v-observe-visibility="
-                    !comments.shown
-                        ? isVisible => fetchComments(isVisible, true)
-                        : false
-                "
+                v-observe-visibility="{
+                    callback: isVisible => fetchComments(isVisible, true),
+                    once: true,
+                }"
             >
                 <comments-list
                     :loading="comments.loading"
@@ -102,7 +101,6 @@ export default {
             items: [],
         },
         comments: {
-            shown: false,
             loading: false,
         },
     }),
@@ -131,7 +129,6 @@ export default {
             if (hasNextPage === false) return;
 
             this.comments.loading = true;
-            this.comments.shown = true;
 
             if (!this.$store.hasModule(['data', 'dataComments'])) {
                 this.$store.registerModule(['data', 'dataComments'], dataComments, { preserveState: true });

--- a/pages/Single.vue
+++ b/pages/Single.vue
@@ -31,29 +31,27 @@
             <list-share :url="data.main.link" />
         </div>
 
-        <div class="bg-light py-3 p-lg-5">
-            <template
-                v-if="data.related"
-            >
-                <list-related :data="data.related" />
+        <template
+            v-if="data.related"
+        >
+            <list-related :data="data.related" />
 
-                <hr class="d-none d-lg-block">
-            </template>
+            <hr class="d-none d-lg-block">
+        </template>
 
-            <div
-                v-observe-visibility="
-                    !comments.shown
-                        ? isVisible => fetchComments(isVisible, true)
-                        : false
-                "
-            >
-                <comments-list
-                    :loading="comments.loading"
-                    :comments="data.comments"
-                    :single-id="data.main.id"
-                    @is-visible-last="fetchComments(true)"
-                />
-            </div>
+        <div
+            v-observe-visibility="
+                !comments.shown
+                    ? isVisible => fetchComments(isVisible, true)
+                    : false
+            "
+        >
+            <comments-list
+                :loading="comments.loading"
+                :comments="data.comments"
+                :single-id="data.main.id"
+                @is-visible-last="fetchComments(true)"
+            />
         </div>
 
         <lazy-photoswipe

--- a/pages/Single.vue
+++ b/pages/Single.vue
@@ -69,6 +69,12 @@ import CommentsList from '~/components/CommentsList.vue';
 
 Vue.directive('observe-visibility', ObserveVisibility);
 
+const registerModules = (store) => {
+    store.$registerModules([
+        { name: ['data', 'dataSingle'], imported: dataSingle, preserveStateCheck: true },
+    ]);
+};
+
 export default {
     components: {
         ListItemInfo,
@@ -82,9 +88,7 @@ export default {
     ],
 
     async asyncData({ store, route }) {
-        if (!store.hasModule(['data', 'dataSingle'])) {
-            store.registerModule(['data', 'dataSingle'], dataSingle, { preserveState: true });
-        }
+        registerModules(store);
 
         let actionName = 'data/fetchPageSingle';
         if (route.params.singleType === 'post') actionName = 'data/fetchPagePost';
@@ -106,14 +110,9 @@ export default {
     }),
 
     mounted() {
-        this.setDataPhotoswipe();
-    },
+        registerModules(this.$store);
 
-    beforeDestroy() {
-        this.$store.unregisterModule(['data', 'dataSingle']);
-        if (this.$store.hasModule(['data', 'dataComments'])) {
-            this.$store.unregisterModule(['data', 'dataComments']);
-        }
+        this.setDataPhotoswipe();
     },
 
     methods: {

--- a/pages/Single.vue
+++ b/pages/Single.vue
@@ -5,9 +5,7 @@
             class="entry-img-hero"
             v-html="data.main.featuredMedia/* eslint-disable-line vue/no-v-html */"
         />
-        <div
-            class="container-fluid"
-        >
+        <div class="entry-body">
             <h1
                 class="entry-title"
             >
@@ -33,13 +31,11 @@
             <list-share :url="data.main.link" />
         </div>
 
-        <div class="bg-light">
+        <div class="bg-light py-3 p-lg-5">
             <template
                 v-if="data.related"
             >
-                <div class="container-fluid">
-                    <list-related :data="data.related" />
-                </div>
+                <list-related :data="data.related" />
 
                 <hr class="d-none d-lg-block">
             </template>
@@ -50,7 +46,6 @@
                         ? isVisible => fetchComments(isVisible, true)
                         : false
                 "
-                class="container-fluid"
             >
                 <comments-list
                     :loading="comments.loading"

--- a/pages/Single.vue
+++ b/pages/Single.vue
@@ -1,10 +1,5 @@
 <template>
     <div v-if="data">
-        <div
-            v-if="data.main.featuredMedia"
-            class="entry-img-hero"
-            v-html="data.main.featuredMedia/* eslint-disable-line vue/no-v-html */"
-        />
         <div class="entry-body">
             <div class="entry-header">
                 <h1>
@@ -111,18 +106,6 @@ export default {
             loading: false,
         },
     }),
-
-    head() {
-        const bodyClass = this.data.main.featuredMedia && 'body-single-hero';
-
-        if (!bodyClass) return null;
-
-        return {
-            bodyAttrs: {
-                class: [bodyClass],
-            },
-        };
-    },
 
     mounted() {
         this.setDataPhotoswipe();

--- a/pages/Single.vue
+++ b/pages/Single.vue
@@ -29,13 +29,10 @@
                 v-html="data.main.content/* eslint-disable-line vue/no-v-html */"
             />
             <list-share :url="data.main.link" />
-            <template
+            <list-related
                 v-if="data.related"
-            >
-                <list-related :data="data.related" />
-
-                <hr class="d-none d-lg-block">
-            </template>
+                :data="data.related"
+            />
             <div
                 v-observe-visibility="
                     !comments.shown

--- a/pages/Single.vue
+++ b/pages/Single.vue
@@ -32,7 +32,7 @@
                 :data="data.related"
             />
             <comments-list
-                :loading="comments.loading"
+                ref="comments"
                 :comments="data.comments"
                 :single-id="data.main.id"
                 @is-visible-last="fetchComments(true)"
@@ -99,9 +99,6 @@ export default {
             index: false,
             items: [],
         },
-        comments: {
-            loading: false,
-        },
     }),
 
     mounted() {
@@ -112,7 +109,10 @@ export default {
 
     methods: {
         async fetchComments(isVisible, checkForData) {
-            if (!isVisible && !this.comments.loading) return;
+            const { classList: commentsClass } = this.$refs.comments.$el;
+            const loading = commentsClass.contains('loading');
+
+            if (!isVisible && !loading) return;
 
             if (checkForData && this.data.comments) return;
 
@@ -122,13 +122,13 @@ export default {
 
             if (hasNextPage === false) return;
 
-            this.comments.loading = true;
+            commentsClass.add('loading');
 
             await this.$store.dispatch('data/fetchComments', {
                 route: this.$route,
             });
 
-            this.comments.loading = false;
+            commentsClass.remove('loading');
         },
         setDataPhotoswipe() {
             this.$refs.content.querySelectorAll('img').forEach((img, index) => {

--- a/pages/Single.vue
+++ b/pages/Single.vue
@@ -29,29 +29,27 @@
                 v-html="data.main.content/* eslint-disable-line vue/no-v-html */"
             />
             <list-share :url="data.main.link" />
-        </div>
+            <template
+                v-if="data.related"
+            >
+                <list-related :data="data.related" />
 
-        <template
-            v-if="data.related"
-        >
-            <list-related :data="data.related" />
-
-            <hr class="d-none d-lg-block">
-        </template>
-
-        <div
-            v-observe-visibility="
-                !comments.shown
-                    ? isVisible => fetchComments(isVisible, true)
-                    : false
-            "
-        >
-            <comments-list
-                :loading="comments.loading"
-                :comments="data.comments"
-                :single-id="data.main.id"
-                @is-visible-last="fetchComments(true)"
-            />
+                <hr class="d-none d-lg-block">
+            </template>
+            <div
+                v-observe-visibility="
+                    !comments.shown
+                        ? isVisible => fetchComments(isVisible, true)
+                        : false
+                "
+            >
+                <comments-list
+                    :loading="comments.loading"
+                    :comments="data.comments"
+                    :single-id="data.main.id"
+                    @is-visible-last="fetchComments(true)"
+                />
+            </div>
         </div>
 
         <lazy-photoswipe

--- a/pages/Single.vue
+++ b/pages/Single.vue
@@ -28,7 +28,10 @@
                 class="entry-content"
                 v-html="data.main.content/* eslint-disable-line vue/no-v-html */"
             />
-            <list-share :url="data.main.link" />
+            <list-share
+                class="scroll-x scroll-hide-bar"
+                :url="data.main.link"
+            />
             <list-related
                 v-if="data.related"
                 :data="data.related"

--- a/pages/Single.vue
+++ b/pages/Single.vue
@@ -6,23 +6,23 @@
             v-html="data.main.featuredMedia/* eslint-disable-line vue/no-v-html */"
         />
         <div class="entry-body">
-            <h1
-                class="entry-title"
-            >
-                {{ data.main.title }}
-            </h1>
-            <list-item-info
-                :data="[{
-                    icon: 'date',
-                    text: $options.filters.formatDate(data.main.date)
-                }, {
-                    icon: 'folder',
-                    links: data.main.categories
-                }, {
-                    icon: 'comment',
-                    text: data.main.commentsNumber
-                }]"
-            />
+            <div class="entry-header">
+                <h1>
+                    {{ data.main.title }}
+                </h1>
+                <list-item-info
+                    :data="[{
+                        icon: 'date',
+                        text: $options.filters.formatDate(data.main.date)
+                    }, {
+                        icon: 'folder',
+                        links: data.main.categories
+                    }, {
+                        icon: 'comment',
+                        text: data.main.commentsNumber
+                    }]"
+                />
+            </div>
             <div
                 ref="content"
                 class="entry-content"

--- a/pages/Single.vue
+++ b/pages/Single.vue
@@ -58,6 +58,8 @@ import ListShare from '~/components/ListShare.vue';
 import ListRelated from '~/components/ListRelated.vue';
 import CommentsList from '~/components/CommentsList.vue';
 
+const cssGallery = () => import('../assets/scss/05-components/gallery-tiled.scss');
+
 const registerModules = (store) => {
     store.$registerModules([
         { name: ['data', 'dataSingle'], imported: dataSingle, preserveStateCheck: true },
@@ -100,6 +102,11 @@ export default {
             items: [],
         },
     }),
+
+    created() {
+        const hasEntrysGalleryJetpack = this.data.main.content.indexOf('tiled-gallery') !== -1; /* indexOf is faster */// eslint-disable-line unicorn/prefer-includes
+        if (hasEntrysGalleryJetpack) cssGallery();
+    },
 
     mounted() {
         registerModules(this.$store);

--- a/plugins/store-utils.js
+++ b/plugins/store-utils.js
@@ -1,0 +1,33 @@
+const registerModules = (store, modules) => {
+    const preserveStateCheck = (state, path) => {
+        if (!path.length) return !!state;
+
+        const currentPathKey = path[0];
+        return !!preserveStateCheck(state[currentPathKey], path.slice(1));
+    };
+
+    modules.forEach((module) => {
+        if (store.hasModule(module.name)) return;
+
+        Object.assign(module, {
+            options: {
+                ...module.options,
+                ...(
+                    module.preserveStateCheck && {
+                        preserveState: preserveStateCheck(store.state, module.name),
+                    }
+                ),
+            },
+        });
+
+        store.registerModule(
+            module.name,
+            module.imported,
+            module.options,
+        );
+    });
+};
+
+export default ({ store }, inject) => {
+    inject('registerModules', (modules) => registerModules(store, modules));
+};

--- a/services/comments.js
+++ b/services/comments.js
@@ -4,7 +4,7 @@ import { objectRenameKeys } from '../utils';
 
 export async function fetchComments({
     $axios,
-    singleId,
+    singleSlug,
     after = null,
 }) {
     const onPage = 10;
@@ -15,7 +15,7 @@ export async function fetchComments({
         data: {
             query: `
                 query GET_COMMENTS_FOR_POST(
-                    $id: ID,
+                    $singleSlug: String,
                     $first: Int,
                     $after: String
                 ) {
@@ -23,7 +23,7 @@ export async function fetchComments({
                         first: $first,
                         after: $after,
                         where: {
-                            contentId: $id
+                            contentName: $singleSlug
                             parent: null
                             order: DESC
                         }
@@ -56,7 +56,7 @@ export async function fetchComments({
                 }
             `,
             variables: {
-                id: singleId,
+                singleSlug,
                 first: onPage,
                 after,
             },

--- a/store/data.js
+++ b/store/data.js
@@ -53,16 +53,15 @@ export default {
             set(state, [dataKeyPage, 'timestamp', dataKeyFirst], new Date().getTime());
 
             const stateKeys = Object.keys(state);
-            if (stateKeys.length > pagesToKeep) {
-                const keyToDelete = stateKeys
-                    .filter((key) => key !== dataKeyPage)
-                    .reduce((prev, curr) => {
-                        if (state[prev].timestamp.main < state[curr].timestamp.main) {
-                            return prev;
-                        }
+            const keyPages = stateKeys.filter((key) => key !== dataKeyPage && key[0] === '/' && state[key].timestamp);
+            if (keyPages.length > pagesToKeep) {
+                const keyToDelete = keyPages.reduce((prev, curr) => {
+                    if (state[prev].timestamp.main < state[curr].timestamp.main) {
+                        return prev;
+                    }
 
-                        return curr;
-                    });
+                    return curr;
+                });
 
                 del(state, [keyToDelete]);
             }

--- a/store/lazy/data-single-comments.js
+++ b/store/lazy/data-single-comments.js
@@ -8,10 +8,10 @@ export default {
             const pageKey = route.fullPath;
             const currentPage = getters.currentPage(pageKey);
             const pageComments = currentPage.comments;
-            const pageSingleId = currentPage.main.id;
+            const pageSingleSlug = route.params.singleSlug;
             let commentsFrom = null;
 
-            if (!currentPage || !pageSingleId) throw new Error('`fetchComments` needs `currentPage` or `pageSingleId`.');
+            if (!currentPage || !pageSingleSlug) throw new Error('`fetchComments` needs `currentPage` or `pageSingleSlug`.');
 
             if (pageComments && Object.keys(pageComments.pageInfo).length) {
                 if (pageComments.pageInfo.hasNextPage) {
@@ -21,7 +21,7 @@ export default {
 
             const response = await fetchComments({
                 $axios: this.$axios,
-                singleId: pageSingleId,
+                singleSlug: pageSingleSlug,
                 after: commentsFrom,
             });
 

--- a/store/lazy/data-single-comments.js
+++ b/store/lazy/data-single-comments.js
@@ -11,7 +11,7 @@ export default {
             const pageSingleSlug = route.params.singleSlug;
             let commentsFrom = null;
 
-            if (!currentPage || !pageSingleSlug) throw new Error('`fetchComments` needs `currentPage` or `pageSingleSlug`.');
+            if (!pageSingleSlug) throw new Error('`fetchComments` needs `pageSingleSlug`.');
 
             if (pageComments && Object.keys(pageComments.pageInfo).length) {
                 if (pageComments.pageInfo.hasNextPage) {

--- a/store/lazy/data-single-comments.js
+++ b/store/lazy/data-single-comments.js
@@ -11,7 +11,7 @@ export default {
             const pageSingleId = currentPage.main.id;
             let commentsFrom = null;
 
-            if (!currentPage || !pageSingleId) throw new Error('`fetchSingleComments` needs `page` or `pageSingleId`.');
+            if (!currentPage || !pageSingleId) throw new Error('`fetchComments` needs `currentPage` or `pageSingleId`.');
 
             if (pageComments && Object.keys(pageComments.pageInfo).length) {
                 if (pageComments.pageInfo.hasNextPage) {


### PR DESCRIPTION
- closes #42 
- fixes errors from trying to process empty state modules, keys that are not pages
- makes some ui's from single page scrollable on mobile
- adds a `.box` block
- makes grid responsible for content widths
- adds a layout-hero component and use it only in `Single` route
- removes id dependency from comments action and bring first comments on ssr too
- adds and use `$registerModules` global utility
- make related block from single pages, full width
- fix some comments error